### PR TITLE
Add offline detection and handling of bad ice connection states

### DIFF
--- a/app/components/EnsureOnline.tsx
+++ b/app/components/EnsureOnline.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react'
+import { useIsOnline } from '~/hooks/useIsOnline'
+
+export interface EnsureOnlineProps {
+	children?: ReactNode
+	fallback?: ReactNode
+}
+
+export function EnsureOnline(props: EnsureOnlineProps) {
+	const isOnline = useIsOnline()
+
+	if (!isOnline) {
+		return props.fallback
+	}
+
+	return props.children
+}

--- a/app/components/HighPacketLossWarningsToast.tsx
+++ b/app/components/HighPacketLossWarningsToast.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import Toast, { Root } from '~/components/Toast'
+import { useConditionForAtLeast } from '~/hooks/useConditionForAtLeast'
 import type Peer from '~/utils/Peer.client'
 import { useRoomContext } from '../hooks/useRoomContext'
 import { Icon } from './Icon/Icon'
@@ -21,21 +22,6 @@ export function usePacketLossInformation(): Partial<
 	}, [peer])
 
 	return debugInfo ?? {}
-}
-
-function useConditionForAtLeast(condition: boolean, time: number) {
-	const [value, setValue] = useState(condition)
-
-	useEffect(() => {
-		let timeout = window.setTimeout(() => {
-			setValue(condition)
-		}, time)
-		return () => {
-			clearTimeout(timeout)
-		}
-	}, [condition, time])
-
-	return value
 }
 
 export function HighPacketLossWarningsToast() {
@@ -66,7 +52,7 @@ export function HighPacketLossWarningsToast() {
 
 	return (
 		<Root duration={Infinity}>
-			<div className="text-sm space-y-2">
+			<div className="space-y-2 text-sm">
 				<div className="font-bold">
 					<Toast.Title className="flex items-center gap-2">
 						<Icon type="WifiIcon" />
@@ -78,7 +64,7 @@ export function HighPacketLossWarningsToast() {
 					<div className="text-gray-500 dark:text-gray-200">
 						<div>Packet Loss</div>
 						<div className="flex gap-4">
-							<div className="flex gap-1 items-center">
+							<div className="flex items-center gap-1">
 								<div className="sr-only">Outbound</div>
 								<Icon
 									className="text-gray-400 dark:text-gray-300"
@@ -86,7 +72,7 @@ export function HighPacketLossWarningsToast() {
 								/>
 								<span>{outbound}%</span>
 							</div>
-							<div className="flex gap-1 items-center">
+							<div className="flex items-center gap-1">
 								<div className="sr-only">Inbound</div>
 								<Icon
 									className="text-gray-400 dark:text-gray-300"

--- a/app/components/IceDisconnectedToast.tsx
+++ b/app/components/IceDisconnectedToast.tsx
@@ -1,0 +1,30 @@
+import Toast, { Root } from '~/components/Toast'
+import { useConditionForAtLeast } from '~/hooks/useConditionForAtLeast'
+import { useRoomContext } from '../hooks/useRoomContext'
+import { Icon } from './Icon/Icon'
+
+export function IceDisconnectedToast() {
+	const { iceConnectionState } = useRoomContext()
+
+	const disconnectedForAtLeastTwoSeconds = useConditionForAtLeast(
+		iceConnectionState === 'disconnected',
+		2000
+	)
+
+	if (!disconnectedForAtLeastTwoSeconds) {
+		return null
+	}
+
+	return (
+		<Root duration={Infinity}>
+			<div className="space-y-2 text-sm">
+				<div className="font-bold">
+					<Toast.Title className="flex items-center gap-2">
+						<Icon type="WifiIcon" />
+						ICE disconnected
+					</Toast.Title>
+				</div>
+			</div>
+		</Root>
+	)
+}

--- a/app/hooks/useConditionForAtLeast.ts
+++ b/app/hooks/useConditionForAtLeast.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react'
+
+export function useConditionForAtLeast(condition: boolean, time: number) {
+	const [value, setValue] = useState(condition)
+
+	useEffect(() => {
+		let timeout = window.setTimeout(() => {
+			setValue(condition)
+		}, time)
+		return () => {
+			clearTimeout(timeout)
+		}
+	}, [condition, time])
+
+	return value
+}

--- a/app/hooks/useIsOnline.ts
+++ b/app/hooks/useIsOnline.ts
@@ -1,0 +1,22 @@
+import { useSyncExternalStore } from 'react'
+
+function getSnapshot() {
+	return navigator.onLine
+}
+
+function getServerSnapshot() {
+	return true
+}
+
+function subscribe(callback: () => void) {
+	window.addEventListener('online', callback)
+	window.addEventListener('offline', callback)
+	return () => {
+		window.removeEventListener('online', callback)
+		window.removeEventListener('offline', callback)
+	}
+}
+
+export function useIsOnline() {
+	return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+}

--- a/app/hooks/useRoomContext.ts
+++ b/app/hooks/useRoomContext.ts
@@ -13,6 +13,7 @@ export type RoomContextType = {
 	userMedia: UserMedia
 	peer: Peer | null
 	peerDebugInfo?: PeerDebugInfo
+	iceConnectionState: RTCIceConnectionState
 	room: ReturnType<typeof useRoom>
 	pushedTracks: {
 		video?: string

--- a/app/routes/_room.$roomName.room.tsx
+++ b/app/routes/_room.$roomName.room.tsx
@@ -7,6 +7,7 @@ import { useMeasure, useMount, useWindowSize } from 'react-use'
 import { Button } from '~/components/Button'
 import { CameraButton } from '~/components/CameraButton'
 import { HighPacketLossWarningsToast } from '~/components/HighPacketLossWarningsToast'
+import { IceDisconnectedToast } from '~/components/IceDisconnectedToast'
 import { Icon } from '~/components/Icon/Icon'
 import { LeaveRoomButton } from '~/components/LeaveRoomButton'
 import { MicButton } from '~/components/MicButton'
@@ -305,6 +306,7 @@ function JoinedRoom({ bugReportsEnabled }: { bugReportsEnabled: boolean }) {
 				</div>
 			</div>
 			<HighPacketLossWarningsToast />
+			<IceDisconnectedToast />
 		</PullAudioTracks>
 	)
 }

--- a/app/routes/_room.tsx
+++ b/app/routes/_room.tsx
@@ -3,7 +3,9 @@ import { json } from '@remix-run/cloudflare'
 import { Outlet, useLoaderData, useParams } from '@remix-run/react'
 import { useState } from 'react'
 import invariant from 'tiny-invariant'
+import { EnsureOnline } from '~/components/EnsureOnline'
 import { EnsurePermissions } from '~/components/EnsurePermissions'
+import { Icon } from '~/components/Icon/Icon'
 
 import { usePeerConnection } from '~/hooks/usePeerConnection'
 import usePushedTrack from '~/hooks/usePushedTrack'
@@ -23,7 +25,20 @@ export const loader = async ({ context }: LoaderFunctionArgs) => {
 export default function RoomWithPermissions() {
 	return (
 		<EnsurePermissions>
-			<Room />
+			<EnsureOnline
+				fallback={
+					<div className="grid h-full place-items-center">
+						<div>
+							<h1 className="flex items-center gap-3 text-3xl font-black">
+								<Icon type="SignalSlashIcon" />
+								You are offline
+							</h1>
+						</div>
+					</div>
+				}
+			>
+				<Room />
+			</EnsureOnline>
 		</EnsurePermissions>
 	)
 }
@@ -37,7 +52,7 @@ function Room() {
 
 	const userMedia = useUserMedia(mode)
 	const room = useRoom({ roomName, userMedia })
-	const { peer, debugInfo } = usePeerConnection()
+	const { peer, debugInfo, iceConnectionState } = usePeerConnection()
 
 	const pushedVideoTrack = usePushedTrack(peer, userMedia.videoStreamTrack)
 	const pushedAudioTrack = usePushedTrack(peer, userMedia.audioStreamTrack)
@@ -54,6 +69,7 @@ function Room() {
 		userDirectoryUrl,
 		peer,
 		peerDebugInfo: debugInfo,
+		iceConnectionState,
 		room,
 		pushedTracks: {
 			video: pushedVideoTrack,

--- a/app/utils/Peer.client.ts
+++ b/app/utils/Peer.client.ts
@@ -190,6 +190,7 @@ export default class Peer {
 		)
 
 		this.pc.setLocalDescription(await this.pc.createOffer())
+		this.pc.addEventListener('iceconnectionstatechange', this.handleIceFailure)
 
 		this.pc.ontrack = (event) => {
 			if (event.transceiver.mid === null) return
@@ -566,6 +567,27 @@ export default class Peer {
 			outboundPacketLossPercentage:
 				this.outboundPacketLossPercentageEwma.value(),
 		}
+	}
+
+	handleIceFailure = async () => {
+		const { iceConnectionState } = this.pc
+		if (iceConnectionState === 'closed' || iceConnectionState === 'failed') {
+			alert(
+				`Oh no! It appears that your connection closed unexpectedly. We've copied your session id to your clipboard, and will now reload the page to reconnect!`
+			)
+			if (this.sessionId) {
+				await navigator.clipboard.writeText(this.sessionId)
+			}
+			window.location.reload()
+		}
+	}
+
+	destroy() {
+		this.pc.removeEventListener(
+			'iceconnectionstatechange',
+			this.handleIceFailure
+		)
+		this.pc.close()
 	}
 }
 


### PR DESCRIPTION
High level overview of a few things in this PR:

1. The `EnsureOnline` component will render the `fallback` prop when the user is not online. This will cause the entire meeting room to unmount, and when it re-mounts all of the behavior for connecting to the meeting room will be triggered again!
2. We will show a toast notification when ice connection state is `disconnected` (which is recoverable!)
3. If ice connection state unexpectedly gets into either `closed` or `failed`, we will copy the session id to clipboard and reload the page. Note that we unbind the event listener for this in the `destroy` method of the `Peer` class, so it will not be triggered when the room is unmounting due to a navigation or the user being offline.