### PR TITLE
fix blank tracelink behaviour

### DIFF
--- a/app/utils/populateTraceLink.ts
+++ b/app/utils/populateTraceLink.ts
@@ -2,7 +2,7 @@ export default function populateTraceLink(
 	sessionID: string,
 	traceLink?: string
 ) {
-	if (traceLink === undefined) return undefined
+	if (!traceLink) return undefined
 	const url = new URL(traceLink)
 
 	const end = +new Date()

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "orange-meets",
 			"dependencies": {
 				"@heroicons/react": "^2.1.1",
 				"@mediapipe/selfie_segmentation": "^0.1.1675465747",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+	"name": "orange-meets",
 	"module": "worker.js",
 	"private": true,
 	"sideEffects": false,


### PR DESCRIPTION
When TRACE_LINK isn't defined, some of the calls to populateTraceLink might be with a blank string. This makes populateTraceLink throw when trying to construct a new URL. The fix is to test with a negation instead.

(I also defined `name` under package.json)