### PR TITLE
use DurableObject from cloudflare:workers

### DIFF
--- a/remix.config.js
+++ b/remix.config.js
@@ -4,7 +4,9 @@ module.exports = {
 	ignoredRouteFiles: ['**/.*'],
 	server: './server.ts',
 	serverConditions: ['worker'],
-	serverDependenciesToBundle: [/^(?!__STATIC_CONTENT_MANIFEST).*$/],
+	serverDependenciesToBundle: [
+		/^(?!__STATIC_CONTENT_MANIFEST|cloudflare:workers).*$/,
+	],
 	serverMainFields: ['browser', 'module', 'main'],
 	serverMinify: true,
 	serverModuleFormat: 'esm',


### PR DESCRIPTION
Discovered that we can use cloudflare:workers if we add it to serverDependenciesToBundle in remix.config.js. Rewrote the ChatRoom DO to use that.