### PR TITLE
don't spread classname into AlertDialog.Content

### DIFF
--- a/app/components/AlertDialog.tsx
+++ b/app/components/AlertDialog.tsx
@@ -19,7 +19,7 @@ Overlay.displayName = 'Overlay'
 export const Content = forwardRef<
 	HTMLDivElement,
 	AlertDialog.AlertDialogContentProps
->(({ children, ...rest }, ref) => (
+>(({ className: _className, children, ...rest }, ref) => (
 	<AlertDialog.Content
 		ref={ref}
 		className={cn(


### PR DESCRIPTION
I accidentally removed this destructuring in https://github.com/cloudflare/orange/pull/46, bringing it back