### PR TITLE
chore(): Set a min-width on desktop to have a static size

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -33,7 +33,7 @@ export default function Index() {
 	return (
 		<div className="flex flex-col items-center justify-center h-full p-4 mx-auto">
 			<div className="flex-1"></div>
-			<div className="space-y-6">
+			<div className="space-y-6 md:min-w-96">
 				<div>
 					<h1 className="text-3xl font-bold">🍊 Orange Meets</h1>
 					<div className="flex items-center justify-between gap-3">
@@ -71,7 +71,10 @@ export default function Index() {
 					<summary className="text-zinc-500 dark:text-zinc-400">
 						Or join a room
 					</summary>
-					<Form className="flex items-end w-full gap-4 pt-4" method="post">
+					<Form
+						className="flex items-end gap-4 md:justify-between items-end w-full pt-4"
+						method="post"
+					>
 						<div className="space-y-2">
 							<Label htmlFor="room">Room name</Label>
 							<Input name="room" id="room" required />

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -72,7 +72,7 @@ export default function Index() {
 						Or join a room
 					</summary>
 					<Form
-						className="flex items-end gap-4 md:justify-between items-end w-full pt-4"
+						className="grid items-end gap-4 grid-cols-[1fr_auto] w-full pt-4"
 						method="post"
 					>
 						<div className="space-y-2">

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -33,7 +33,7 @@ export default function Index() {
 	return (
 		<div className="flex flex-col items-center justify-center h-full p-4 mx-auto">
 			<div className="flex-1"></div>
-			<div className="space-y-6 md:min-w-96">
+			<div className="space-y-6 sm:min-w-96">
 				<div>
 					<h1 className="text-3xl font-bold">🍊 Orange Meets</h1>
 					<div className="flex items-center justify-between gap-3">


### PR DESCRIPTION
Right now, the content box does not have a minimum width on desktop. If the pane gets collapsed, the entire content box becomes bigger.

Before:
![image](https://github.com/user-attachments/assets/bff1eded-cb92-4aa3-9b3c-8516530581ef)
![image](https://github.com/user-attachments/assets/9f83c739-0d92-497c-80b7-1b1f41e2ff8c)

After:
![image](https://github.com/user-attachments/assets/65789b03-2123-4d73-8b70-f82424e95034)
![image](https://github.com/user-attachments/assets/669667f2-f67c-4962-8fcc-7bbbb6d817f4)
