### PR TITLE
Increased ICE disconnected timeout

### DIFF
--- a/app/utils/rxjs/RxjsPeer.client.ts
+++ b/app/utils/rxjs/RxjsPeer.client.ts
@@ -87,7 +87,10 @@ export class RxjsPeer {
 						)
 						subscribe.next(setup())
 					} else if (peerConnection.iceConnectionState === 'disconnected') {
-						const timeoutSeconds = 3
+						// TODO: we should start to inspect the connection stats from here on for
+						// any other signs of trouble to guide what to do next (instead of just hoping
+						// for the best like we do here for now)
+						const timeoutSeconds = 7
 						iceTimeout = window.setTimeout(() => {
 							console.debug(
 								`💥 Peer iceConnectionState was ${peerConnection.iceConnectionState} for more than ${timeoutSeconds} seconds`


### PR DESCRIPTION
Chrome AFAIK sends ICE checks every 2 seconds. And a single lost STUN consent (ICE ping) can result in the ICE connection state to switch to "disconnected". So the current timeout basically mean two lost STUN consents in a row result in us trying to restart the call. That might be a little to aggressive.

As indicated in the additional comment in the code: I would recommend that once ICE disconnected has been reached, that we start looking at PC stats more closely to try to figure out if we should just wait for the connection state to recover, or if we should try to restart.