### PR TITLE
Restore onError handler in server

### DIFF
--- a/app/durableObjects/ChatRoom.server.ts
+++ b/app/durableObjects/ChatRoom.server.ts
@@ -225,17 +225,13 @@ export class ChatRoom extends Server<Env> {
 	onClose() {
 		// while it makes sense to broadcast immediately on close,
 		// it's possible that the websocket just closed for an instant
-		//  and will reconnect momentarily.
+		// and will reconnect momentarily.
 		// so let's just let the alarm handler do the broadcasting.
-		// this.broadcastState()
+		// this.broadcastRoomState()
 	}
 
 	onError(): void | Promise<void> {
-		// while it makes sense to broadcast immediately on close,
-		// it's possible that the websocket just closed for an instant
-		//  and will reconnect momentarily.
-		// so let's just let the alarm handler do the broadcasting.
-		// this.broadcastState()
+		this.broadcastRoomState()
 	}
 
 	async cleanupOldConnections() {


### PR DESCRIPTION
Now that we've fixed the issue where users connecting should try to look up an existing session before creating a new one, we should restore this