### PR TITLE
Remove the initial inactive audio transceiver

### DIFF
--- a/app/utils/rxjs/RxjsPeer.client.ts
+++ b/app/utils/rxjs/RxjsPeer.client.ts
@@ -534,10 +534,6 @@ function createPeerConnection(
 ) {
 	const pc = new RTCPeerConnection(configuration)
 
-	pc.addTransceiver('audio', {
-		direction: 'inactive',
-	})
-
 	return pc
 }
 


### PR DESCRIPTION
As we switch Orange to the new API we no longer need to start a session with an inactive transceiver to start the connection.