### PR TITLE
Highlight participant window when hand is raised

### DIFF
--- a/app/components/Participant.tsx
+++ b/app/components/Participant.tsx
@@ -220,7 +220,7 @@ export const Participant = forwardRef<
 								</Tooltip>
 							)}
 						</div>
-						{user.speaking && (
+						{(user.speaking || user.raisedHand) && (
 							<div
 								className={cn(
 									'pointer-events-none absolute inset-0 h-full w-full border-4 border-orange-400',


### PR DESCRIPTION
This will show the orange outline around a participant when they've got their hand raised!