### PR TITLE
Split error logging from details

### DIFF
--- a/app/durableObjects/ChatRoom.server.ts
+++ b/app/durableObjects/ChatRoom.server.ts
@@ -314,9 +314,13 @@ export class ChatRoom extends Server<Env> {
 	}
 
 	onError(connection: Connection, error: unknown): void | Promise<void> {
+		log({
+			eventName: 'onErrorHandler',
+			error,
+		})
 		return this.getMeetingId().then((meetingId) => {
 			log({
-				eventName: 'onErrorHandler',
+				eventName: 'onErrorHandlerDetails',
 				meetingId,
 				connectionId: connection.id,
 				error,

--- a/app/durableObjects/ChatRoom.server.ts
+++ b/app/durableObjects/ChatRoom.server.ts
@@ -352,7 +352,15 @@ export class ChatRoom extends Server<Env> {
 	async cleanupOldConnections() {
 		const meetingId = await this.getMeetingId()
 		if (!meetingId) log({ eventName: 'meetingIdNotFoundInCleanup' })
+		const websockets = this.ctx.getWebSockets()
 		const connections = [...this.getConnections()]
+		log({
+			eventName: 'cleaningUpConnections',
+			meetingId,
+			connectionsFound: connections.length,
+			websocketsFound: websockets.length,
+			websocketStatuses: websockets.map((w) => w.readyState),
+		})
 		const sessionsToCleanUp = await this.getUsers()
 
 		connections.forEach((connection) =>

--- a/app/utils/logging.ts
+++ b/app/utils/logging.ts
@@ -41,6 +41,10 @@ export type LogEvent =
 	  }
 	| {
 			eventName: 'onErrorHandler'
+			error: unknown
+	  }
+	| {
+			eventName: 'onErrorHandlerDetails'
 			meetingId?: string
 			connectionId: string
 			error: unknown

--- a/app/utils/logging.ts
+++ b/app/utils/logging.ts
@@ -19,6 +19,13 @@ export type LogEvent =
 			connectionId: string
 	  }
 	| {
+			eventName: 'cleaningUpConnections'
+			meetingId?: string
+			connectionsFound: number
+			websocketsFound: number
+			websocketStatuses: number[]
+	  }
+	| {
 			eventName: 'userTimedOut'
 			meetingId?: string
 			connectionId: string


### PR DESCRIPTION
This PR adds a couple more spots to capture some data for debugging. My theory for the mystery user/users leaving is that our cleanup function is removing users when it shouldn't be, and they immediately reconnect. I've added logging so we can see the websocket states when the cleanup runs since this is how partyserver determines which connections to return in `getConnections()`

See https://github.com/threepointone/partyserver/blob/main/packages/partyserver/src/connection.ts#L167-L183