### PR TITLE
Bump node compat date

### DIFF
--- a/wrangler.development.toml
+++ b/wrangler.development.toml
@@ -3,7 +3,7 @@ name = "orange-meets-development"
 account_id = "8477399eb04accc1792af96aeaa25222"
 main = "./build/index.js"
 # https://developers.cloudflare.com/workers/platform/compatibility-dates
-compatibility_date = "2024-06-20"
+compatibility_date = "2024-10-07"
 compatibility_flags = ["nodejs_compat"]
 
 [site]

--- a/wrangler.production.toml
+++ b/wrangler.production.toml
@@ -3,7 +3,7 @@ name = "orange-meets-production"
 account_id = "8477399eb04accc1792af96aeaa25222"
 main = "./build/index.js"
 # https://developers.cloudflare.com/workers/platform/compatibility-dates
-compatibility_date = "2024-06-20"
+compatibility_date = "2024-10-07"
 compatibility_flags = ["nodejs_compat"]
 
 [site]

--- a/wrangler.public.toml
+++ b/wrangler.public.toml
@@ -3,7 +3,7 @@ name = "orange-meets-public"
 account_id = "8477399eb04accc1792af96aeaa25222"
 main = "./build/index.js"
 # https://developers.cloudflare.com/workers/platform/compatibility-dates
-compatibility_date = "2024-06-20"
+compatibility_date = "2024-10-07"
 compatibility_flags = ["nodejs_compat"]
 
 [site]

--- a/wrangler.staging.toml
+++ b/wrangler.staging.toml
@@ -3,7 +3,7 @@ name = "orange-meets-staging"
 account_id = "8477399eb04accc1792af96aeaa25222"
 main = "./build/index.js"
 # https://developers.cloudflare.com/workers/platform/compatibility-dates
-compatibility_date = "2024-06-20"
+compatibility_date = "2024-10-07"
 compatibility_flags = ["nodejs_compat"]
 
 [site]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
 name = "orange-meets"
 # https://developers.cloudflare.com/workers/platform/compatibility-dates
-compatibility_date = "2024-06-20"
+compatibility_date = "2024-10-07"
 main = "./build/index.js"
 compatibility_flags = ["nodejs_compat"]
 


### PR DESCRIPTION
`/new` was broken because nanoid was using `Buffer`, so bumping the node_compat date to fix.