### PR TITLE
Restructure connection checks to look for heartbeat timestamps

### DIFF
--- a/app/hooks/useRoom.ts
+++ b/app/hooks/useRoom.ts
@@ -63,16 +63,16 @@ export default function useRoom({
 		}
 	}, [websocket])
 
-	// // setup a simple ping pong
-	// useEffect(() => {
-	// 	const interval = setInterval(() => {
-	// 		websocket.send(
-	// 			JSON.stringify({ type: 'partyserver-ping' } satisfies ClientMessage)
-	// 		)
-	// 	}, 5000)
-	//
-	// 	return () => clearInterval(interval)
-	// }, [websocket])
+	// setup a heartbeat
+	useEffect(() => {
+		const interval = setInterval(() => {
+			websocket.send(
+				JSON.stringify({ type: 'heartbeat' } satisfies ClientMessage)
+			)
+		}, 5_000)
+
+		return () => clearInterval(interval)
+	}, [websocket])
 
 	const identity = useMemo(
 		() => roomState.users.find((u) => u.id === websocket.id),

--- a/app/types/Messages.ts
+++ b/app/types/Messages.ts
@@ -61,3 +61,6 @@ export type ClientMessage =
 	| {
 			type: 'partyserver-ping'
 	  }
+	| {
+			type: 'heartbeat'
+	  }


### PR DESCRIPTION
This PR removes the websocket connection checks in the alarm, and instead looks for a heartbeat timestamp to evaluate whether or not to consider a user "timed out". This should hopefully resolve the issue we've seen for a while where sometimes random users are "timed out" incorrectly.