### PR TITLE
Provide extra API params and correlation id for openai API calls

### DIFF
--- a/app/durableObjects/ChatRoom.server.ts
+++ b/app/durableObjects/ChatRoom.server.ts
@@ -386,6 +386,8 @@ export class ChatRoom extends Server<Env> {
 						const openAiSession = await CallsNewSession(
 							this.env.CALLS_APP_ID,
 							this.env.CALLS_APP_SECRET,
+							this.env.API_EXTRA_PARAMS,
+							await this.getMeetingId(),
 							true
 						)
 						const openAiTracksResponse = await openAiSession.NewTracks({


### PR DESCRIPTION
We're already passing `correlationId` from browser side to help debug all sessions in a call, adding it now from the durable object when it creates calls sessions and tracks for the OpenAI integration.