### PR TITLE
Fix OpenAPI endpoint usage

### DIFF
--- a/app/durableObjects/ChatRoom.server.ts
+++ b/app/durableObjects/ChatRoom.server.ts
@@ -25,6 +25,7 @@ import {
 } from '~/utils/openai.server'
 
 const alarmInterval = 15_000
+const defaultOpenAIModelID = 'gpt-4o-realtime-preview-2024-10-01'
 
 /**
  * The ChatRoom Durable Object Class
@@ -414,6 +415,8 @@ export class ChatRoom extends Server<Env> {
 						if (instructions) {
 							params.set('instructions', instructions)
 						}
+
+						params.set('model', this.env.OPENAI_MODEL_ID || defaultOpenAIModelID)
 
 						// The Calls's offer is sent to OpenAI
 						const openaiAnswer = await requestOpenAIService(

--- a/app/types/Env.ts
+++ b/app/types/Env.ts
@@ -17,4 +17,5 @@ export type Env = {
 	DB?: D1Database
 	OPENAI_API_TOKEN?: string
 	OPENAI_MODEL_ENDPOINT?: string
+	OPENAI_MODEL_ID?: string
 }


### PR DESCRIPTION
This commit will explicitly set a model ID when calling to OpenAI Realtime, as there was a breaking change where the endpoint will no longer have a default mode, thus causing our example to stop working.