### PR TITLE
feat: implement maximum participants limit

### DIFF
--- a/app/types/Env.ts
+++ b/app/types/Env.ts
@@ -18,4 +18,5 @@ export type Env = {
 	OPENAI_API_TOKEN?: string
 	OPENAI_MODEL_ENDPOINT?: string
 	OPENAI_MODEL_ID?: string
+	MAX_PARTICIPANTS?: number
 }


### PR DESCRIPTION
# Implement Maximum Participants Limit

This PR introduces a feature to limit the number of participants in a room.

## Changes

- Added `MAX_PARTICIPANTS` environment variable in `wrangler.toml` for example `MAX_PARTICIPANTS = 10`
- Updated loader function to parse and validate `MAX_PARTICIPANTS`
- Modified Lobby component to use `maxParticipants` for determining room capacity
- Implemented UI changes to show when a room is full and prevent joining

## How to test

1. Set different values for `MAX_PARTICIPANTS` in `wrangler.toml`
2. Run the application and try to join a room
3. Verify that the room becomes full when the number of participants reaches the set limit
4. Check that the UI updates correctly (button disabled, "Room Full" message shown)

## Notes for reviewers

- Ensure that the error handling for invalid `MAX_PARTICIPANTS` values is sufficient
- Consider if we need additional logging or error reporting for when `MAX_PARTICIPANTS` is not set or invalid

#### close #140