### PR TITLE
Set gain to 0

### DIFF
--- a/app/utils/rxjs/inaudibleAudioTrack$.ts
+++ b/app/utils/rxjs/inaudibleAudioTrack$.ts
@@ -6,10 +6,12 @@ export const inaudibleAudioTrack$ = new Observable<MediaStreamTrack>(
 
 		const oscillator = audioContext.createOscillator()
 		oscillator.type = 'triangle'
+		// roughly sounds like a box fan
 		oscillator.frequency.setValueAtTime(20, audioContext.currentTime)
 
 		const gainNode = audioContext.createGain()
-		gainNode.gain.setValueAtTime(0.01, audioContext.currentTime)
+		// even w/ gain at 0 some packets are sent
+		gainNode.gain.setValueAtTime(0, audioContext.currentTime)
 
 		oscillator.connect(gainNode)
 


### PR DESCRIPTION
Setting gain to 0.01 had a strange effect that I only noticed after merging. I couldn't hear it even with my volume all the way up, UNLESS I turned my volume down, then turned it up again.

Setting gain to 0 alleviates this issue and still sends packets on the track.