### PR TITLE
Revert muting by default in dev env

### DIFF
--- a/app/hooks/useUserMedia.ts
+++ b/app/hooks/useUserMedia.ts
@@ -5,7 +5,6 @@ import { combineLatest, map, of, shareReplay, switchMap, tap } from 'rxjs'
 import invariant from 'tiny-invariant'
 import { blackCanvasStreamTrack } from '~/utils/blackCanvasStreamTrack'
 import blurVideoTrack from '~/utils/blurVideoTrack'
-import { mode } from '~/utils/mode'
 import noiseSuppression from '~/utils/noiseSuppression'
 import { prependDeviceToPrioritizeList } from '~/utils/rxjs/devicePrioritization'
 import { getScreenshare$ } from '~/utils/rxjs/getScreenshare$'
@@ -30,7 +29,16 @@ export default function useUserMedia() {
 		'suppress-noise',
 		false
 	)
-	const [audioEnabled, setAudioEnabled] = useState(mode === 'production')
+	// NOTE: in the past we've set this to be false by default in dev
+	// but as long as we're using the web audio API to generate an inaudible
+	// audio track we shouldn't do this because the audio track will not have
+	// any packets flowing out over the peer connection if the audio context
+	// fails to initialize due to no prior user interaction. If we need
+	// to require user interaction, we might as well have that interaction
+	// be for the user to manually mute themselves and not have to work around
+	// this. Once Calls is handling audio tracks with no data flowing better
+	// we should be able to go back to muting by default in dev.
+	const [audioEnabled, setAudioEnabled] = useState(true)
 	const [videoEnabled, setVideoEnabled] = useState(true)
 	const [screenShareEnabled, setScreenShareEnabled] = useState(false)
 	const [videoUnavailableReason, setVideoUnavailableReason] =


### PR DESCRIPTION
As much as I wanted to have mute on by default in dev env, it's causing issues w/ our "inaudible" track since generating it w/ the web audio API requires a user interaction.

If we _have_ to have some user interaction, we might as well just revert this change and let the required interaction be that you need to mute yourself manually in dev.

Hopefully some day we can go back to mute by default in dev. 😵‍💫